### PR TITLE
chore: clean up rust-crane template

### DIFF
--- a/rust-crane/.gitignore
+++ b/rust-crane/.gitignore
@@ -2,3 +2,4 @@ result
 result*
 .direnv
 .pre-commit-config.yaml
+target

--- a/rust-crane/flake.nix
+++ b/rust-crane/flake.nix
@@ -3,10 +3,7 @@
 
   inputs = {
     nixpkgs.url = "nixpkgs/nixos-unstable";
-    flake-parts = {
-      url = "github:hercules-ci/flake-parts";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
+    flake-parts.url = "github:hercules-ci/flake-parts";
     fenix = {
       url = "github:nix-community/fenix";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -26,13 +23,8 @@
     };
   };
 
-  outputs = inputs @ {
-    self,
-    flake-utils,
-    flake-parts,
-    ...
-  }:
-    flake-parts.lib.mkFlake {inherit inputs;} {
+  outputs = inputs:
+    inputs.flake-parts.lib.mkFlake {inherit inputs;} {
       systems = ["x86_64-linux" "aarch64-linux"];
       imports = [
         ./flake-parts/cargo.nix


### PR DESCRIPTION
- use `packages` from `mkShell` instead of `buildInputs` and `nativeBuildInputs`
- `rust-toolchain` is now exposed as a package
- clean up `checks` specification
- enable rustfmt pre-commit-hook by default
- update `.gitignore`
- clean up `outputs` function